### PR TITLE
Docker: Move setup.yml content to separate file

### DIFF
--- a/dockerFiles/Dockerfile
+++ b/dockerFiles/Dockerfile
@@ -18,10 +18,10 @@ RUN echo -e "[bahmni] \nname=Bahmni development repository for RHEL/CentOS 6\nba
     && rpm -ivh /opt/jre-7u79-linux-x64.rpm \
     && yum install -y http://yum.postgresql.org/9.2/redhat/rhel-6-x86_64/pgdg-centos92-9.2-7.noarch.rpm \
     && yum install -y ftp://195.220.108.108/linux/Mandriva/devel/cooker/x86_64/media/contrib/release/mx-1.4.5-1-mdv2012.0.x86_64.rpm \
-    && echo -e "selinux_state: disabled \npostgres_version: 9.2 \ntimezone: Asia/Kolkata \nimplementation_name: default \nbahmni_support_group: bahmni_support \nbahmni_support_user: bahmni_support \nbahmni_password_hash: $1$IW4OvlrH$Kui/55oif8W3VZIrnX6jL1 \nbahmni_repo_url: http://repo.mybahmni.org/rpm/bahmni/ \nopenerp_url: https://erp-$container_name.mybahmni.org \ndocker: yes " > /etc/bahmni-installer/setup.yml \
     && sed -i "1,100 s/^/#/" /opt/bahmni-installer/bahmni-playbooks/roles/dcm4chee-oracle-java/tasks/main.yml \
-    && pip uninstall -y docutils \
-    && bahmni -ilocal install
+    && pip uninstall -y docutils
+ADD setup.yml /etc/bahmni-installer/setup.yml
+RUN bahmni -ilocal install
 RUN if [[ -f "/${container_name}/letsencrypt/cert.crt" && -f "/${container_name}/letsencrypt/chained.pem" && -f "/${container_name}/letsencrypt/domain.key" ]] && openssl x509 -checkend 86400 -noout -in "/${container_name}/letsencrypt/chained.pem" ; then \
 	echo "inside if" ;\
     rm -rf /etc/bahmni-certs/* ;\

--- a/dockerFiles/setup.yml
+++ b/dockerFiles/setup.yml
@@ -1,0 +1,10 @@
+selinux_state: disabled
+postgres_version: 9.2
+timezone: Asia/Kolkata
+implementation_name: default
+bahmni_support_group: bahmni_support
+bahmni_support_user: bahmni_support
+bahmni_password_hash: $1$IW4OvlrH$Kui/55oif8W3VZIrnX6jL1
+bahmni_repo_url: http://repo.mybahmni.org/rpm/bahmni/
+openerp_url: https://erp-$container_name.mybahmni.org
+docker: yes


### PR DESCRIPTION
# Summary
To assist users who need to add `omods` or other configuration to their `setup.yml` file, I've refactored the `Dockerfile` ever-so-slightly, such that it uses an external `setup.yml` file rather than creating one dynamically.

If merged, this will require an update to the documentation.